### PR TITLE
Remove accidental gitlink and ignore .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ yarn-error.log*
 # Misc local files
 *.pem
 *.local
+.claude/


### PR DESCRIPTION
This pull request removes the `.claude/worktrees/wizardly-yonath` subproject reference, detaching it from the repository.