### PR TITLE
fix: enhance email sending binding type definition in submitContactForm

### DIFF
--- a/app/actions/contact.ts
+++ b/app/actions/contact.ts
@@ -225,7 +225,18 @@ export async function submitContactForm(
     const confirmationSubject = "We received your message";
 
     // Prefer Cloudflare Email Workers binding `SEND_EMAIL` when available on globalThis.
-    const sendBinding = (globalThis as any).SEND_EMAIL;
+
+    type SendEmailBinding = {
+      send: (options: {
+        from: string;
+        to: string;
+        replyTo?: string;
+        subject: string;
+        text: string;
+        html: string;
+      }) => Promise<void>;
+    };
+    const sendBinding = (globalThis as { SEND_EMAIL?: SendEmailBinding }).SEND_EMAIL;
 
     if (sendBinding && typeof sendBinding.send === "function") {
       await sendBinding.send({


### PR DESCRIPTION
This pull request makes a small but important improvement to the `submitContactForm` function in `app/actions/contact.ts`. The change introduces a more precise TypeScript type definition for the `SEND_EMAIL` binding, enhancing type safety and code clarity.

- Type safety improvement:
  * Added a `SendEmailBinding` type to explicitly define the expected structure and method signature for the `SEND_EMAIL` Cloudflare binding, and updated the code to use this type when accessing `globalThis.SEND_EMAIL`.