### PR TITLE
Handle directory read errors in content manifest generation

### DIFF
--- a/scripts/generate-content-manifest.mjs
+++ b/scripts/generate-content-manifest.mjs
@@ -11,9 +11,20 @@ const manifest = {}
 
 for (const collection of collections) {
   const directory = path.join(contentDir, collection)
-  const files = (await fs.readdir(directory))
-    .filter((filename) => filename.endsWith('.mdx'))
-    .sort((left, right) => left.localeCompare(right))
+
+  let files = []
+
+  try {
+    files = (await fs.readdir(directory))
+      .filter((filename) => filename.endsWith('.mdx'))
+      .sort((left, right) => left.localeCompare(right))
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      files = []
+    } else {
+      throw error
+    }
+  }
 
   manifest[collection] = {}
 


### PR DESCRIPTION
This pull request improves the robustness of the `scripts/generate-content-manifest.mjs` script by handling cases where a content collection directory does not exist. If a directory is missing, the script now safely continues without failing, ensuring that missing directories do not cause errors during manifest generation.

Error handling improvements:

* Added a `try/catch` block around reading collection directories in `scripts/generate-content-manifest.mjs` to gracefully handle missing directories (`ENOENT` errors) by treating them as empty, while still throwing other errors.