### PR TITLE
Add SECURITY.md with vulnerability reporting and disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,13 @@
 
 ## Reporting a Vulnerability
 
-Please report suspected vulnerabilities privately by email to [hello@sonicverse.eu](mailto:hello@sonicverse.eu) with the subject line `Security Report`.
+Use this intake order for all security reports:
 
-Do not open a public GitHub issue for security-sensitive reports. Public issues can expose users, deployments, or maintainers before a fix is available.
+- Primary: GitHub Private Vulnerability Reporting for this repository
+- Fallback: [support@sonicverse.eu](mailto:support@sonicverse.eu) with the subject line `Security Report`
+- Do not use public GitHub issues for security-sensitive reports
 
-If email is not practical, you may also use the contact form on the Sonicverse website and clearly mark the message as a security report. Email is still preferred for the fastest handling.
+Public GitHub issues can expose users, deployments, or maintainers before a fix is available, so please use a private reporting channel.
 
 ## What to Include
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately by email to [hello@sonicverse.eu](mailto:hello@sonicverse.eu) with the subject line `Security Report`.
+
+Do not open a public GitHub issue for security-sensitive reports. Public issues can expose users, deployments, or maintainers before a fix is available.
+
+If email is not practical, you may also use the contact form on the Sonicverse website and clearly mark the message as a security report. Email is still preferred for the fastest handling.
+
+## What to Include
+
+To help us validate and respond efficiently, please include:
+
+- A clear summary of the issue and the affected component or file path
+- Steps to reproduce the problem
+- The potential impact, including what an attacker could do
+- Any proof of concept, logs, screenshots, or sample requests that help demonstrate the issue
+- Version, environment, commit hash, or deployment details if relevant
+- Your name or preferred contact details for follow-up
+
+Please avoid accessing, modifying, or retaining other people's data while testing. If you believe sensitive data may have been exposed, stop testing and tell us immediately in your report.
+
+## Response Timeline and Process
+
+We aim to handle reports using the following timeline:
+
+- Acknowledgment within 3 business days
+- Initial triage and severity assessment within 7 business days
+- A follow-up status update within 14 business days after triage
+- Ongoing updates at reasonable intervals until the issue is resolved or a mitigation is available
+
+Our handling process is generally:
+
+1. Confirm receipt of the report
+2. Validate and reproduce the issue
+3. Assess severity, scope, and affected systems
+4. Prepare a fix or mitigation
+5. Coordinate release timing and disclosure with the reporter when appropriate
+
+Response and resolution times can vary depending on the complexity and impact of the issue, but we will communicate progress as clearly as possible.
+
+## Disclosure Guidelines
+
+We ask for coordinated disclosure. Please do not publicly disclose the vulnerability until:
+
+- We confirm that a fix or mitigation is available, or
+- We agree on a public disclosure timeline together
+
+When a report is confirmed, we may publish a security advisory, release notes, or other public notice once users have had a reasonable opportunity to update or mitigate.
+
+## Scope
+
+This policy applies to this repository and related deployment or runtime behavior directly associated with the Sonicverse website project.


### PR DESCRIPTION
## Summary
- add a repository security policy in `SECURITY.md`
- document private vulnerability reporting via `hello@sonicverse.eu`
- define expected reporter details, response timelines, handling steps, and coordinated disclosure guidance

## Testing
- Not run (not requested)