### PR TITLE
Update README for clearer onboarding and contributor guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Update the copied files with values that match your environment. The most import
 - `NEXT_PUBLIC_SITE_URL` for canonical metadata in Worker preview and deployment environments.
 - `NEXT_PUBLIC_IMAGE_WORKER_URL` if image requests should be served from a dedicated image worker URL.
 
-If you use Cloudflare Email Workers bindings instead of direct provider credentials, keep `SEND_EMAIL` configured in the Worker environment as described in the existing comments inside [.env.example](/Users/rikvisser/.codex/worktrees/41ca/website/.env.example) and [.dev.vars.example](/Users/rikvisser/.codex/worktrees/41ca/website/.dev.vars.example).
+If you use Cloudflare Email Workers bindings instead of direct provider credentials, keep `SEND_EMAIL` configured in the Worker environment as described in the existing comments inside [.env.example](./.env.example) and [.dev.vars.example](./.dev.vars.example).
 
 ### Local Development
 
@@ -62,7 +62,7 @@ Run the OpenNext Cloudflare preview flow when you want to test the Worker build 
 npm run preview
 ```
 
-For deployment-specific details, see [DEPLOYMENT.md](/Users/rikvisser/.codex/worktrees/41ca/website/DEPLOYMENT.md).
+For deployment-specific details, see [DEPLOYMENT.md](./DEPLOYMENT.md).
 
 ## Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
 # Sonicverse Website
 
-A Next.js application optimized for Cloudflare Workers deployment using OpenNext.
+[![Cloudflare Worker Preview](https://github.com/sonicverse-eu/website/actions/workflows/cloudflare-preview.yml/badge.svg)](https://github.com/sonicverse-eu/website/actions/workflows/cloudflare-preview.yml)
+![Next.js 16](https://img.shields.io/badge/Next.js-16-000000?logo=next.js)
+![React 19](https://img.shields.io/badge/React-19-149ECA?logo=react&logoColor=white)
+![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)
 
-## Features
+Sonicverse Website is the public web presence for Sonicverse, built with Next.js App Router, MDX content, and Cloudflare Workers via OpenNext. It combines marketing pages, editorial content, and a contact workflow in a deployment setup designed for edge delivery.
 
-- ✅ Next.js 16 with React 19
-- ✅ Cloudflare Workers deployment
-- ✅ OpenNext integration
-- ✅ Optimized for edge runtime
-- ✅ Email functionality via Cloudflare Workers
-- ✅ R2 storage integration
-- ✅ Cloudflare Images support
+## What's Inside
+
+- Marketing and company pages built with the Next.js App Router.
+- MDX-backed blog, changelog, and roadmap content.
+- A contact flow that sends submissions through the configured email delivery path.
+- Cloudflare-focused build, preview, and deployment scripts powered by OpenNext.
 
 ## Getting Started
+
+### Prerequisites
+
+- A recent Node.js LTS release and `npm`.
+- A Cloudflare account plus Wrangler CLI if you want to preview or deploy the Worker build.
 
 ### Installation
 
@@ -20,49 +27,106 @@ A Next.js application optimized for Cloudflare Workers deployment using OpenNext
 npm install
 ```
 
-### Development
+### Environment Setup
+
+Create the local environment files used by Next.js and the Cloudflare Worker preview:
+
+```bash
+cp .env.example .env.local
+cp .dev.vars.example .dev.vars
+```
+
+Update the copied files with values that match your environment. The most important settings are:
+
+- `EMAIL_SENDER` and `EMAIL_RECIPIENT` for contact form delivery.
+- `NEXT_PUBLIC_SITE_URL` for canonical metadata in Worker preview and deployment environments.
+- `NEXT_PUBLIC_IMAGE_WORKER_URL` if image requests should be served from a dedicated image worker URL.
+
+If you use Cloudflare Email Workers bindings instead of direct provider credentials, keep `SEND_EMAIL` configured in the Worker environment as described in the existing comments inside [.env.example](/Users/rikvisser/.codex/worktrees/41ca/website/.env.example) and [.dev.vars.example](/Users/rikvisser/.codex/worktrees/41ca/website/.dev.vars.example).
+
+### Local Development
+
+Run the standard Next.js development server:
 
 ```bash
 npm run dev
 ```
 
-### Preview with Cloudflare Workers
+Then open [http://localhost:3000](http://localhost:3000).
+
+### Cloudflare Worker Preview
+
+Run the OpenNext Cloudflare preview flow when you want to test the Worker build locally:
 
 ```bash
 npm run preview
 ```
 
-### Deployment
+For deployment-specific details, see [DEPLOYMENT.md](/Users/rikvisser/.codex/worktrees/41ca/website/DEPLOYMENT.md).
+
+## Usage Examples
+
+### Start the app locally
+
+```bash
+npm run dev
+```
+
+### Run the project checks
+
+```bash
+npm run lint
+npm run typecheck
+npm run build
+```
+
+### Build the Cloudflare Worker bundle
+
+```bash
+npm run build:worker
+```
+
+### Preview the Worker locally
+
+```bash
+npm run preview
+```
+
+### Deploy to Cloudflare
 
 ```bash
 npm run deploy
 ```
 
-## Project Structure
+## Common Commands
 
-- `app/` - Next.js app router pages
-- `app/actions/` - Server actions
-- `app/services/` - API routes
-- `app/blog/` - Blog content
-- `public/` - Static assets
-- `.open-next/` - OpenNext build output
-- `wrangler.jsonc` - Cloudflare Workers configuration
-- `next.config.ts` - Next.js configuration
-- `open-next.config.ts` - OpenNext configuration
+| Command | What it does |
+| --- | --- |
+| `npm run dev` | Starts the Next.js development server. |
+| `npm run lint` | Runs ESLint across the project. |
+| `npm run typecheck` | Runs TypeScript in no-emit mode. |
+| `npm run build` | Builds the Next.js app. |
+| `npm run build:worker` | Builds the OpenNext Cloudflare Worker output. |
+| `npm run preview` | Builds and previews the Worker locally. |
+| `npm run deploy` | Builds and deploys the Worker to Cloudflare. |
+| `npm run cf-typegen` | Regenerates Cloudflare environment types. |
+| `npm run clean` | Removes local build artifacts. |
 
-## Configuration
+## Contributing
 
-See [DEPLOYMENT.md](DEPLOYMENT.md) for detailed deployment instructions.
+Contributions are welcome through GitHub Issues and Pull Requests. If you want to propose a bug fix, content change, or improvement to the site experience, start by checking the open issues or opening a new one with the context needed to reproduce the problem or explain the idea.
 
-## Environment Variables
+This repository does not currently ship a dedicated `CONTRIBUTING.md`, so the working expectation is:
 
-Copy `.dev.vars.example` to `.dev.vars` and configure:
+- keep changes focused and readable;
+- run `npm run lint`, `npm run typecheck`, and `npm run build` before opening a PR;
+- include screenshots or preview details when a change affects the UI or content presentation;
+- use the existing Cloudflare preview workflow on pull requests as an extra validation step.
 
-```
-EMAIL_SENDER = "Sonicverse <hello@sonicverse.eu>"
-EMAIL_RECIPIENT = "hello@sonicverse.eu"
-```
+## Links
 
-## License
-
-MIT
+- Live site: [sonicverse.eu](https://sonicverse.eu)
+- Repository: [github.com/sonicverse-eu/website](https://github.com/sonicverse-eu/website)
+- GitHub organization: [github.com/sonicverse-eu](https://github.com/sonicverse-eu)
+- Issues: [github.com/sonicverse-eu/website/issues](https://github.com/sonicverse-eu/website/issues)
+- Contact: [hello@sonicverse.eu](mailto:hello@sonicverse.eu)


### PR DESCRIPTION
## Summary
- rewrite the README to describe the Sonicverse website as a Next.js App Router site deployed to Cloudflare via OpenNext
- add badges, onboarding setup steps, environment file guidance, usage examples, and a command reference
- document the current contribution path through GitHub issues and pull requests, plus key project and contact links
- remove outdated or misleading README content, including the previous license mention

## Testing
- Not run (not requested)